### PR TITLE
Move hashes to the beginning

### DIFF
--- a/src/routes/companies.ts
+++ b/src/routes/companies.ts
@@ -10,7 +10,7 @@ const companies = {
   register: async function (server: Hapi.Server) {
     server.route({
       method: "POST",
-      path: `/webhook/hubspot/companies/${config.hsHash}`,
+      path: `/${config.hsHash}/webhook/hubspot/companies`,
       handler: handlePostCompany,
       options: {
         validate: {

--- a/src/routes/deals.ts
+++ b/src/routes/deals.ts
@@ -14,7 +14,7 @@ const deals = {
   register: async function (server: Hapi.Server) {
     server.route({
       method: "POST",
-      path: `/webhooks/hubspot/deals/${config.hsHash}`,
+      path: `/${config.hsHash}/webhooks/hubspot/deals`,
       handler: handlePostDeal,
       options: {
         validate: {
@@ -30,7 +30,7 @@ const deals = {
 
     server.route({
       method: "GET",
-      path: `/deals/{id}/profile/${config.dealsHash}`,
+      path: `/${config.dealsHash}/deals/{id}/profile`,
       handler: handleGetUprightProfile,
       options: {
         validate: {
@@ -43,7 +43,7 @@ const deals = {
 
     server.route({
       method: "GET",
-      path: `/deals/{id}/profileURL/${config.dealsHash}`,
+      path: `/${config.dealsHash}/deals/{id}/profileURL`,
       handler: handleGetUprightProfileURL,
       options: {
         validate: {

--- a/src/routes/interactions.ts
+++ b/src/routes/interactions.ts
@@ -10,7 +10,7 @@ const interactions = {
   register: async function (server: Hapi.Server) {
     server.route({
       method: "POST",
-      path: `/webhook/slack/interactions/${config.slackHash}`,
+      path: `/${config.slackHash}/webhook/slack/interactions`,
       handler: handleUpdateUid,
       options: {
         validate: {


### PR DESCRIPTION
Move hashes to the beginning of the url to avoid them leaking through Zapier