### PR TITLE
17 redis connection doesnt work on paid heroku plans

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,25 @@ import companyRoutes from "./routes/companies";
 import interactionRoutes from "./routes/interactions";
 import uprightInternalGet from "./methods/upright-internal-get";
 
+const redisTLSOptions =
+  process.env.NODE_ENV === "production"
+    ? {
+        socket: {
+          tls: true,
+          rejectUnauthorized: false,
+        },
+      }
+    : {};
+
+const redisOptions = {
+  url:
+    process.env.REDIS_TLS_URL ||
+    process.env.REDIS_URL ||
+    "redis://0.0.0.0:6379",
+  db: 0,
+  ...redisTLSOptions,
+};
+
 const server = Hapi.server({
   port: process.env.PORT || 3000,
   host: process.env.HOST || "0.0.0.0",
@@ -16,13 +35,7 @@ const server = Hapi.server({
       name: "redis",
       provider: {
         constructor: CatboxRedis,
-        options: {
-          url:
-            process.env.REDIS_TLS_URL ||
-            process.env.REDIS_URL ||
-            "redis://0.0.0.0:6379",
-          db: 0,
-        },
+        options: redisOptions,
       },
     },
   ],

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,9 @@ import uprightInternalGet from "./methods/upright-internal-get";
 const redisTLSOptions =
   process.env.NODE_ENV === "production"
     ? {
-        tls: {},
+        tls: {
+          rejectUnauthorized: false,
+        },
       }
     : {};
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,10 @@ const server = Hapi.server({
       provider: {
         constructor: CatboxRedis,
         options: {
-          url: process.env.REDIS_URL || "redis://0.0.0.0:6379",
+          url:
+            process.env.REDIS_TLS_URL ||
+            process.env.REDIS_URL ||
+            "redis://0.0.0.0:6379",
           db: 0,
         },
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,10 +11,7 @@ import uprightInternalGet from "./methods/upright-internal-get";
 const redisTLSOptions =
   process.env.NODE_ENV === "production"
     ? {
-        socket: {
-          tls: true,
-          rejectUnauthorized: false,
-        },
+        tls: {},
       }
     : {};
 


### PR DESCRIPTION
Description: #17.

There's little to test locally. Basically my proof of it working is the status of this review app:

https://net-impact-b-17-redis-c-voawuv.herokuapp.com/status

The link above is a temporary Heroku app with paid plans for Heroku and Heroku Data for Redis. If there was an error with the Redis connection, the app would crash when started. However, because the status is "ok", the app was able to start, meaning that the Redis TLS connection was successful.