### PR TITLE
Return a 204 response if no profile is found

### DIFF
--- a/src/controllers/deal.ts
+++ b/src/controllers/deal.ts
@@ -61,11 +61,7 @@ const handleGetUprightProfile = async (
 ) => {
   const profile = await getUprightProfile(request.params.id, false);
   if (!profile) {
-    return h
-      .response(
-        `Could not find an existing Upright profile on HubSpot for deal ${request.params.id}`
-      )
-      .code(404);
+    return h.response().code(204);
   }
   return profile;
 };


### PR DESCRIPTION
## Description

#18 

## How to test

- [ ] GET /deals/123/profile should return an empty 204 response instead of a 404 response with a message