### PR TITLE
Fix/company link not showing on single result lists

### DIFF
--- a/src/services/slack/interactiveBotPayload.ts
+++ b/src/services/slack/interactiveBotPayload.ts
@@ -52,10 +52,10 @@ export function getSlackPayload(
   companyID: string,
   profiles: UprightProfile[]
 ) {
-  let message: string;
-  profiles.length > 1
-    ? (message = `Which of the following profiles matches *${company}* on Hubspot?`)
-    : (message = `Does the following profile match *${company}* on Hubspot?`);
+  const message: string =
+    profiles.length > 1
+      ? `Which of the following profiles matches *${company}* on Hubspot?`
+      : `Does the following profile match *${company}* on Hubspot?`;
   const blocks: Array<KnownBlock> = [
     {
       type: "header",

--- a/src/services/slack/interactiveBotPayload.ts
+++ b/src/services/slack/interactiveBotPayload.ts
@@ -52,10 +52,7 @@ export function getSlackPayload(
   companyID: string,
   profiles: UprightProfile[]
 ) {
-  const message: string =
-    profiles.length > 1
-      ? `Which of the following profiles matches *${company}* on Hubspot?`
-      : `Does the following profile match *${company}* on Hubspot?`;
+  const message = `Which of the following profiles matches *${company}* on Hubspot?`;
   const blocks: Array<KnownBlock> = [
     {
       type: "header",
@@ -82,86 +79,45 @@ export function getSlackPayload(
     elements: [],
   };
 
-  if (profiles.length > 1) {
-    profiles.map((profile) => {
-      const URlink = `${config.uprightPlatformRoot}/company/${profile.id}`;
-      blocks.push(
-        {
-          type: "section",
-          text: {
-            type: "mrkdwn",
-            text: `*<${URlink}|${profile.name}>*: ${truncate(
-              profile.description?.replace(/[\r\n]/gm, ""),
-              250
-            )}`,
-          },
-          accessory: {
-            type: "button",
-            text: {
-              type: "plain_text",
-              text: ":point_left: This one!",
-              emoji: true,
-            },
-            value: valueString(profile.id, companyID),
-            confirm: confirmMatch(profile.name),
-          },
-        },
-        {
-          type: "divider",
-        }
-      );
-    });
-
-    buttons.elements?.push({
-      type: "button",
-      text: {
-        type: "plain_text",
-        text: "None of these :confused:",
-        emoji: true,
-      },
-      value: valueString("no_match_found", companyID),
-      confirm: confirmNoMatch(null),
-    });
-  } else {
+  profiles.map((profile) => {
+    const URlink = `${config.uprightPlatformRoot}/company/${profile.id}`;
     blocks.push(
       {
         type: "section",
         text: {
           type: "mrkdwn",
-          text: `*${profiles[0].name}:* ${truncate(
-            profiles[0].description?.replace(/[\r\n]/gm, ""),
-            350
+          text: `*<${URlink}|${profile.name}>*: ${truncate(
+            profile.description?.replace(/[\r\n]/gm, ""),
+            250
           )}`,
+        },
+        accessory: {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: ":point_left: This one!",
+            emoji: true,
+          },
+          value: valueString(profile.id, companyID),
+          confirm: confirmMatch(profile.name),
         },
       },
       {
         type: "divider",
       }
     );
+  });
 
-    buttons.elements?.push(
-      {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Yep, it's a match!",
-          emoji: true,
-        },
-        value: valueString(profiles[0].id, companyID),
-        confirm: confirmMatch(profiles[0].name),
-      },
-      {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Nope, not a match!",
-          emoji: true,
-        },
-        value: valueString("no_match_found", companyID),
-        confirm: confirmNoMatch(profiles[0].name),
-      }
-    );
-  }
+  buttons.elements?.push({
+    type: "button",
+    text: {
+      type: "plain_text",
+      text: "None of these :confused:",
+      emoji: true,
+    },
+    value: valueString("no_match_found", companyID),
+    confirm: confirmNoMatch(null),
+  });
 
   blocks.push(buttons);
   return blocks;


### PR DESCRIPTION
## Description

The company link didn't show up on single-result messages.

I decided to refactor the code so that there's no separate view for a single-result message. @MelissaAlasalmi I know it was your idea and it made the bot more clever! However, it required quite a lot of code, affecting maintainability, and also caused some inconsistency in the UI. That's why I decided to remove the single-result code, apologies for that!

## How to test

First, update your environment variables:
- SLACK_TOKEN to use the new "Net Impact Test" app on api.slack.com
- SLACK_PROFILE_CHANNEL to use the recently renamed cr-net-impact-bot-profiles-test channel
- SLACK_ADMIN_CHANNEL to use the recently renamed cr-net-impact-bot-admin-test channel

This way, your tests won't use the production app and its interaction webhook url.

Second, create two new companies to HubSpot: 1) UPM 2) Stora Enso. (You can use other ones, too, but these have several results and one result, respectively.)

Third, send a POST request with Postman to the hubspot/companies route for each of the companies. You should see the interactive messages with links to the profiles for all results of both companies.