### PR TITLE
Fix/company link not showing on single result lists 2

### DIFF
--- a/src/services/slack/interactiveBotPayload.ts
+++ b/src/services/slack/interactiveBotPayload.ts
@@ -52,10 +52,10 @@ export function getSlackPayload(
   companyID: string,
   profiles: UprightProfile[]
 ) {
-  let message: string;
-  profiles.length > 1
-    ? (message = `Which of the following profiles matches *${companyName}* on Hubspot?`)
-    : (message = `Does the following profile match *${companyName}* on Hubspot?`);
+  const message =
+    profiles.length > 1
+      ? `Which of the following profiles matches *${companyName}* on Hubspot?`
+      : `Does the following profile match *${companyName}* on Hubspot?`;
   const blocks: Array<KnownBlock> = [
     {
       type: "header",

--- a/src/services/slack/interactiveBotPayload.ts
+++ b/src/services/slack/interactiveBotPayload.ts
@@ -29,7 +29,7 @@ const confirmMatch = (companyName: string) => {
   return confirmation;
 };
 
-const confirmNoMatch = (companyName: string | null) => {
+const confirmNoMatch = (companyName?: string) => {
   const confirmation: Confirm = {
     title: {
       type: "plain_text",
@@ -37,7 +37,7 @@ const confirmNoMatch = (companyName: string | null) => {
     },
     text: {
       type: "plain_text",
-      text: `${companyName ? companyName : "There"} is not a match?`,
+      text: `${companyName || "There"} is not a match?`,
     },
     confirm: {
       type: "plain_text",
@@ -120,7 +120,7 @@ export function getSlackPayload(
         emoji: true,
       },
       value: valueString("no_match_found", companyID),
-      confirm: confirmNoMatch(null),
+      confirm: confirmNoMatch(),
     });
   } else {
     blocks.push(

--- a/src/services/slack/interactiveBotPayload.ts
+++ b/src/services/slack/interactiveBotPayload.ts
@@ -48,14 +48,14 @@ const confirmNoMatch = (companyName?: string) => {
 };
 
 export function getSlackPayload(
-  company: string,
+  companyName: string,
   companyID: string,
   profiles: UprightProfile[]
 ) {
   let message: string;
   profiles.length > 1
-    ? (message = `Which of the following profiles matches *${company}* on Hubspot?`)
-    : (message = `Does the following profile match *${company}* on Hubspot?`);
+    ? (message = `Which of the following profiles matches *${companyName}* on Hubspot?`)
+    : (message = `Does the following profile match *${companyName}* on Hubspot?`);
   const blocks: Array<KnownBlock> = [
     {
       type: "header",

--- a/src/services/slack/interactiveBotPayload.ts
+++ b/src/services/slack/interactiveBotPayload.ts
@@ -1,4 +1,9 @@
-import { ActionsBlock, Confirm, KnownBlock } from "@slack/web-api";
+import {
+  Confirm,
+  DividerBlock,
+  KnownBlock,
+  SectionBlock,
+} from "@slack/web-api";
 import { UprightProfile } from "../../../types";
 import config from "../../config";
 import { truncate } from "./utils";
@@ -52,11 +57,12 @@ export function getSlackPayload(
   companyID: string,
   profiles: UprightProfile[]
 ) {
-  const message =
-    profiles.length > 1
-      ? `Which of the following profiles matches *${companyName}* on Hubspot?`
-      : `Does the following profile match *${companyName}* on Hubspot?`;
+  if (profiles.length < 1) throw new Error("No profiles provided");
+
+  const isSingleResult = profiles.length === 1;
+
   const blocks: Array<KnownBlock> = [
+    // Header
     {
       type: "header",
       text: {
@@ -69,23 +75,19 @@ export function getSlackPayload(
       type: "section",
       text: {
         type: "mrkdwn",
-        text: message,
+        text: isSingleResult
+          ? `Does the following profile match *${companyName}* on Hubspot?`
+          : `Which of the following profiles matches *${companyName}* on Hubspot?`,
       },
     },
     {
       type: "divider",
     },
-  ];
 
-  const buttons: ActionsBlock = {
-    type: "actions",
-    elements: [],
-  };
-
-  if (profiles.length > 1) {
-    profiles.map((profile) => {
+    // Search results
+    ...profiles.flatMap((profile): (SectionBlock | DividerBlock)[] => {
       const URlink = `${config.uprightPlatformRoot}/company/${profile.id}`;
-      blocks.push(
+      return [
         {
           type: "section",
           text: {
@@ -95,74 +97,71 @@ export function getSlackPayload(
               250
             )}`,
           },
-          accessory: {
-            type: "button",
-            text: {
-              type: "plain_text",
-              text: ":point_left: This one!",
-              emoji: true,
-            },
-            value: valueString(profile.id, companyID),
-            confirm: confirmMatch(profile.name),
-          },
+          ...(isSingleResult
+            ? // For a single result, no button is attached. See Actions instead.
+              {}
+            : // For multiple results, attach a selection button to each.
+              {
+                accessory: {
+                  type: "button",
+                  text: {
+                    type: "plain_text",
+                    text: ":point_left: This one!",
+                    emoji: true,
+                  },
+                  value: valueString(profile.id, companyID),
+                  confirm: confirmMatch(profile.name),
+                },
+              }),
         },
         {
           type: "divider",
-        }
-      );
-    });
-
-    buttons.elements?.push({
-      type: "button",
-      text: {
-        type: "plain_text",
-        text: "None of these :confused:",
-        emoji: true,
-      },
-      value: valueString("no_match_found", companyID),
-      confirm: confirmNoMatch(),
-    });
-  } else {
-    blocks.push(
-      {
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `*${profiles[0].name}:* ${truncate(
-            profiles[0].description?.replace(/[\r\n]/gm, ""),
-            350
-          )}`,
         },
-      },
-      {
-        type: "divider",
-      }
-    );
+      ];
+    }),
 
-    buttons.elements?.push(
-      {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Yep, it's a match!",
-          emoji: true,
-        },
-        value: valueString(profiles[0].id, companyID),
-        confirm: confirmMatch(profiles[0].name),
-      },
-      {
-        type: "button",
-        text: {
-          type: "plain_text",
-          text: "Nope, not a match!",
-          emoji: true,
-        },
-        value: valueString("no_match_found", companyID),
-        confirm: confirmNoMatch(profiles[0].name),
-      }
-    );
-  }
+    // Actions
+    {
+      type: "actions",
+      elements: isSingleResult
+        ? // For a single result, show the selection buttons ("yes/no") for the result
+          [
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "Yep, it's a match!",
+                emoji: true,
+              },
+              value: valueString(profiles[0].id, companyID),
+              confirm: confirmMatch(profiles[0].name),
+            },
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "Nope, not a match!",
+                emoji: true,
+              },
+              value: valueString("no_match_found", companyID),
+              confirm: confirmNoMatch(profiles[0].name),
+            },
+          ]
+        : // For multiple results, show the negative selection button ("none of the above")
+          [
+            {
+              type: "button",
+              text: {
+                type: "plain_text",
+                text: "None of these :confused:",
+                emoji: true,
+              },
+              value: valueString("no_match_found", companyID),
+              confirm: confirmNoMatch(),
+            },
+          ],
+    },
+  ];
 
-  blocks.push(buttons);
   return blocks;
 }


### PR DESCRIPTION
_Take 2 to #21_

## Description

The company link didn't show up on single-result messages.

Also features some refactoring to avoid to make code more DRY and follow the functional style.

## How to test

First, update your environment variables:
- SLACK_TOKEN to use the new "Net Impact Test" app on api.slack.com
- SLACK_PROFILE_CHANNEL to use the recently renamed cr-net-impact-bot-profiles-test channel
- SLACK_ADMIN_CHANNEL to use the recently renamed cr-net-impact-bot-admin-test channel

This way, your tests won't use the production app and its interaction webhook url.

Second, create two new companies to HubSpot: 1) UPM 2) Stora Enso. (You can use other ones, too, but these have several results and one result, respectively.)

Third, send a POST request with Postman to the hubspot/companies route for each of the companies. You should see the interactive messages with links to the profiles for all results of both companies.